### PR TITLE
新規アカウントでプロフィールを開いたときのエラー修正

### DIFF
--- a/php/www/user/index.php
+++ b/php/www/user/index.php
@@ -61,7 +61,9 @@ $user = $stmt->fetch(PDO::FETCH_ASSOC);
                                 <div class="col">
                                     <h3 class="mb-0"><?= htmlspecialchars($user['displayname']) ?></h3>
                                     <p class="text-secondary mb-1">@<?= htmlspecialchars($user['name']) ?></p>
-                                    <p class="mb-2"><?= nl2br(htmlspecialchars($user['bio'])) ?></p>
+                                    <?php if (!empty($user['bio'])): ?>
+                                        <p class="mb-2"><?= nl2br(htmlspecialchars($user['bio'])) ?></p>
+                                    <?php endif; ?>
                                     <ul class="d-flex flex-wrap mb-0 p-0 gap-2">
                                         <?php if (!empty($user['github_url'])): ?>
                                             <li class="list-inline-item m-0">


### PR DESCRIPTION
## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->

## 変更点

新規アカウントを作成しプロフィールに飛ぶとデータベース上にbioが存在しないために起きるエラーの修正
データがある時だけif文を使って表示するように変更

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
